### PR TITLE
Update example.ipynb

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -77,7 +77,7 @@
     "### From passing from OK to OK/pi^n\n",
     "precision_loss_quotient=0\n",
     "for q in range(p,i):\n",
-    "    precision_loss_quotient+=n*valuation(p,math.factorial(q))\n",
+    "    precision_loss_quotient+=n*valuation(math.factorial(q), p)\n",
     "    \n",
     "### From lifting nabla to Nygaard\n",
     "precision_loss_nygaard=n*math.floor(i*(i-1)/2)\n",


### PR DESCRIPTION
the standard valuation function takes in the prime as the 2nd argument, or use my_valuation (which takes in primes in the first argument)